### PR TITLE
Match Function Class When Translating

### DIFF
--- a/src/Zomp.EFCore.BinaryFunctions/Query/Internal/BinaryTranslator.cs
+++ b/src/Zomp.EFCore.BinaryFunctions/Query/Internal/BinaryTranslator.cs
@@ -19,6 +19,11 @@ public class BinaryTranslator(ISqlExpressionFactory sqlExpressionFactory, IRelat
     {
         ArgumentNullException.ThrowIfNull(method);
 
+        if (method.DeclaringType != typeof(DbFunctionsExtensions))
+        {
+            return null;
+        }
+
         return method.Name switch
         {
             nameof(DbFunctionsExtensions.GetBytes) => GetBytes(arguments[1]),

--- a/src/Zomp.EFCore.WindowFunctions/Query/Internal/WindowFunctionsTranslator.cs
+++ b/src/Zomp.EFCore.WindowFunctions/Query/Internal/WindowFunctionsTranslator.cs
@@ -13,7 +13,13 @@ public class WindowFunctionsTranslator(ISqlExpressionFactory sqlExpressionFactor
 
     /// <inheritdoc/>
     public SqlExpression? Translate(SqlExpression? instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments, IDiagnosticsLogger<DbLoggerCategory.Query> logger)
-        => method.Name switch
+    {
+        if (method.DeclaringType != typeof(DbFunctionsExtensions))
+        {
+            return null;
+        }
+
+        return method.Name switch
         {
             nameof(DbFunctionsExtensions.Min) => Parse(arguments, "MIN"),
             nameof(DbFunctionsExtensions.Max) => Parse(arguments, "MAX"),
@@ -48,6 +54,7 @@ public class WindowFunctionsTranslator(ISqlExpressionFactory sqlExpressionFactor
 
             _ => null,
         };
+    }
 
     /// <summary>
     /// Returns max or min sql expression.


### PR DESCRIPTION
This PR closes #27 and makes it so that functions that happen to share names with functions in `DbFunctionsExtensions` won't accidentally get translated.